### PR TITLE
allow user to store his gpg.edn file in home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ boot build-jar push-snapshot
 boot build-jar push-release
 ```
 
+#### Signing
+
 The `gpg.edn` file format:
 
 ```clojure
 {:keyring "/path/to/secring.gpg"
  :user-id "Micha Niskin <micha.niskin@gmail.com>"}
 ```
+
+`gpg.edn` can be global, sourced fom your home directory, or local to your project. Local `gpg.edn` takes precedence over global one.
 
 ## License
 

--- a/src/adzerk/bootlaces.clj
+++ b/src/adzerk/bootlaces.clj
@@ -9,8 +9,8 @@
    [adzerk.bootlaces.template :as t]))
 
 (def ^:private +gpg-config+
-  (let [f (io/file "gpg.edn")]
-    (when (.exists f) (read-string (slurp f)))))
+  (let [gpg-files (filter #(.exists %) [(io/file "gpg.edn") (io/file (System/getProperty "user.home") "gpg.edn")])]
+    (when-not (empty? gpg-files) (read-string (slurp (first gpg-files))))))
 
 (def ^:private +last-commit+
   (try (last-commit) (catch Throwable _)))


### PR DESCRIPTION
Will check if user directory has a *gpg.edn* in addition to current directory.
*gpg.edn* in current directory is taking precedence.